### PR TITLE
404 errors and user route

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -24,7 +24,7 @@ exports.verify = function(assertion, audience, next) {
 // TODO add heavy cacheing of this. Changing email should be rare.
 exports.userId = function(email, next) {
   users.getId(email, function(err, userId) {
-    if (err) next(Hapi.Error.badRequest(err));
+    if (err) next(err);
     else next(userId);
   });
 };
@@ -32,7 +32,7 @@ exports.userId = function(email, next) {
 // retrieve the meta data for a user
 exports.user = function(userId, next) {
   users.getUser(userId, function(err, user) {
-    if (err) next(Hapi.Error.badRequest(err));
+    if (err) next(err);
     else next(user);
   });
 };

--- a/lib/users.js
+++ b/lib/users.js
@@ -3,6 +3,10 @@ const async = require('async');
 const kvstore = require('picl-server/lib/kvstore');
 const config = require('./config.js');
 const util = require('./util.js');
+const Hapi = require('hapi');
+
+var internalError = Hapi.Error.internal;
+var notFound = Hapi.Error.notFound;
 
 var kv = kvstore.connect(config.get('kvstore'));
 
@@ -61,7 +65,8 @@ exports.create = function(email, cb) {
 // This method returns the userId currently associated with an email address.
 exports.getId = function(email, cb) {
   kv.get(email + '/userid', function(err, result) {
-    cb(err, result && result.value);
+    if (err) return cb(internalError(err));
+    cb(null, result && result.value);
   });
 };
 
@@ -82,7 +87,10 @@ exports.addDevice = function(userId, cb) {
     function(devices, cb) {
       if (!devices) return cb('UnknownUser');
       devices.value[id] = initDevice();
-      kv.set(devicesKey, devices.value, function(err) { cb(err, id); });
+      kv.set(devicesKey, devices.value, function(err) {
+        if (err) return cb(internalError(err));
+        cb(null, id);
+      });
     }
   ], cb);
 };
@@ -157,7 +165,10 @@ exports.bumpkA = function(userId, cb) {
       // set new class A key and increment version
       user.value.kA = kA;
       user.value.kA_version++;
-      kv.set(metaKey, user.value, function(err) { cb(err, user.value); });
+      kv.set(metaKey, user.value, function(err) {
+        if (err) return cb(internalError(err));
+        cb(null, user.value);
+      });
     }
   ], cb);
 };
@@ -165,8 +176,8 @@ exports.bumpkA = function(userId, cb) {
 // get meta data associated with a user
 exports.getUser = function(userId, cb) {
   kv.get(userId + '/meta', function(err, doc) {
-    if (err) return cb(err);
-    if (!doc) return cb('UnknownUser');
+    if (err) return cb(internalError(err));
+    if (!doc) return cb(notFound('UnknownUser'));
     cb(null, doc.value);
   });
 };

--- a/routes/device.js
+++ b/routes/device.js
@@ -41,7 +41,11 @@ function create(request) {
   var user = request.pre.user;
 
   users.addDevice(request.pre.userId, function(err, deviceId) {
-    if (err) return request.reply(Hapi.Error.badRequest(err));
+    if (err && err.match(/^Unkown/)) {
+      return request.reply(Hapi.Error.notFound(err));
+    } else if (err) {
+      return request.reply(Hapi.Error.badRequest(err));
+    }
 
     request.reply({
       success: true,

--- a/routes/user.js
+++ b/routes/user.js
@@ -11,6 +11,23 @@ const Str = Hapi.Types.String;
 const Bool = Hapi.Types.Boolean;
 const Num = Hapi.Types.Number;
 
+var getConfig = {
+  description: 'get user meta data',
+  pre: [ prereqs.emailGet, prereqs.userId, prereqs.user ],
+  validate: {
+    query: {
+      email: Str().required()
+    }
+  },
+  response: {
+    schema: {
+      success: Bool().required(),
+      kA: Str().required(),
+      version: Num().integer().required()
+    }
+  }
+};
+
 exports.routes = [
   {
     method: 'POST',
@@ -36,24 +53,15 @@ exports.routes = [
   },
   {
     method: 'GET',
+    path: '/user',
+    handler: get,
+    config: getConfig
+  },
+  {
+    method: 'GET',
     path: '/user/{deviceId?}',
     handler: get,
-    config: {
-      description: 'get user meta data',
-      pre: [ prereqs.emailGet, prereqs.userId, prereqs.user ],
-      validate: {
-        query: {
-          email: Str().required()
-        }
-      },
-      response: {
-        schema: {
-          success: Bool().required(),
-          kA: Str().required(),
-          version: Num().integer().required()
-        }
-      }
-    }
+    config: getConfig
   },
   {
     method: 'POST',

--- a/routes/user.js
+++ b/routes/user.js
@@ -79,10 +79,11 @@ exports.routes = [
 ];
 
 
+
 // create a user by assertion
 function create(request) {
   users.create(request.pre.email, function(err, result) {
-    if (err) return request.reply(Hapi.Error.badRequest(err));
+    if (err) return request.reply(err);
 
     request.reply({
       success: true,
@@ -108,7 +109,7 @@ function get(request) {
 
   // update the device's last kA request time
   users.updateDevice(pre.userId, request.params.deviceId, function(err) {
-    if (err) return request.reply(Hapi.Error.badRequest(err));
+    if (err) return request.reply(err);
 
     request.reply({
       success: true,
@@ -124,11 +125,11 @@ function bump(request) {
 
   // mark all other devices as having a stale key
   users.outdateDevices(pre.userId, request.params.deviceId, function(err) {
-    if (err) return request.reply(Hapi.Error.badRequest(err));
+    if (err) return request.reply(err);
 
     // create a new key and bump the version
     users.bumpkA(pre.userId, function(err, user) {
-      if (err) return request.reply(Hapi.Error.badRequest(err));
+      if (err) return request.reply(err);
 
       request.reply({
         success: true,
@@ -138,3 +139,4 @@ function bump(request) {
     });
   });
 }
+

--- a/test/integration/user.js
+++ b/test/integration/user.js
@@ -71,7 +71,7 @@ describe('user', function() {
   });
 
   it('should get user info without supplying a device ID', function(done) {
-    makeRequest('GET', '/user/?email=' + TEST_EMAIL
+    makeRequest('GET', '/user?email=' + TEST_EMAIL
     , function(res) {
       assert.equal(res.statusCode, 200);
       assert.equal(kA, res.result.kA);
@@ -95,7 +95,7 @@ describe('user', function() {
   });
 
   it('should 404 on unkown user', function(done) {
-    makeRequest('GET', '/user/?email=unknown@example.com'
+    makeRequest('GET', '/user?email=unknown@example.com'
     , function(res) {
       assert.equal(res.statusCode, 404);
 

--- a/test/integration/user.js
+++ b/test/integration/user.js
@@ -94,5 +94,14 @@ describe('user', function() {
     });
   });
 
+  it('should 404 on unkown user', function(done) {
+    makeRequest('GET', '/user/?email=unknown@example.com'
+    , function(res) {
+      assert.equal(res.statusCode, 404);
+
+      done();
+    });
+  });
+
 });
 


### PR DESCRIPTION
Returns 404 errors for unknown users instead of 400. Also makes trailing slash on `/user/` route optional.
